### PR TITLE
use internal hash function to generate the image version

### DIFF
--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -39,7 +39,7 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
     )
 
     # The FQN defines a unique hash for the image.
-    version = version or f'$(echo $(hash {tarball}) | md5sum - | cut -f1 -d" ")'
+    version = version or f'$(echo $(hash {tarball}))'
     fqn = build_rule(
         name = f'{name}_fqn',
         srcs = [tarball],


### PR DESCRIPTION
 Use internal hash function to generate the image version instead of rehashing the value using md5sum. In some cases (macOS for ex) md5sum command does not exist and it's replacement (md5) is located in `/sbin` which is not made available by default. 

