### PR TITLE
added the posibility to save the created docker image into a tar file

### DIFF
--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -101,6 +101,30 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
         test_only = test_only,
         labels = labels,
     )
+
+    # The TAR rule defines an output file for _save so it can be retrivable later 
+    tar = build_rule(
+        name = f'{name}_tar',
+        # srcs = [tarball],
+        cmd = f'echo -n "" >> $OUT',
+        outs = [f'{name}.tar'],
+        deps = [f'{base_image}_fqn' if base_image else None],
+        labels = labels,
+        stamp = True,
+        visibility = visibility,
+        test_only = test_only,
+    )
+
+    # docker image save
+    sh_cmd(
+        name = name + '_save',
+        cmd = f'./$(out_location {docker_build}) && docker image save `cat $SRCS` -o $(out_location {tar})',
+        srcs = [fqn],
+        deps = [docker_build, tar],
+        visibility = visibility,
+        test_only = test_only,
+        labels = labels,
+    )
     return docker_build
 
 


### PR DESCRIPTION
Hi, 
I've added two new rules that will allow to save a docker image into a tar archive. I need this change and #21 because I'm currently working to integrate please into skaffold. 