### PR TITLE
Add syntax highlighting for build_defs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.build_defs linguist-language=Python


### PR DESCRIPTION
Because there's just something that's missing when you look at non-highlighted code. 

Sometimes github can be slow with highlight overrides, but you can see it working here: https://github.com/barlock/pleasings/blob/syntax-highlighting/docker/docker.build_defs

Linguist details: https://github.com/github/linguist#overrides