### PR TITLE
Add nim to Docker test image

### DIFF
--- a/docker/test_image/Dockerfile
+++ b/docker/test_image/Dockerfile
@@ -54,3 +54,6 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
 
 # pip (python deps)
 RUN apt-get install -y python3-pip
+
+# nim dependency
+RUN apt-get install nim


### PR DESCRIPTION
CircleCI failing due to `nim` (and `nimble`) not installed thus unable to build properly.