### PR TITLE
Add package_name as a parameter

### DIFF
--- a/js/yarn.build_defs
+++ b/js/yarn.build_defs
@@ -16,7 +16,7 @@ def yarn_library(name, version, package_name=None, out=None, hashes=None, test_o
     Args:
       name (str): Name of the rule.
       version (str): Version of the package to install.
-      package_name (str): The name of the package. Defaults to the name.
+      package_name (str): The name of the node package. Defaults to name.
       out (str): Output name for this package. Defaults to name.
       hashes (list): List of hashes that outputs must match.
       test_only (bool): If True, can only be depended on by test rules.
@@ -24,7 +24,8 @@ def yarn_library(name, version, package_name=None, out=None, hashes=None, test_o
       visibility (list): Visibility declaration for this rule.
       deps (list): Any other dependencies of the rule.
     """
-    url = 'https://registry.yarnpkg.com/%s/-/%s-%s.tgz' % (package_name or name, package_name or name, version)
+    package_name = package_name or name
+    url = 'https://registry.yarnpkg.com/%s/-/%s-%s.tgz' % (package_name, package_name, version)
     cmd = 'echo "Fetching %s..." && curl -fsSL %s | tar -xz --no-same-owner --no-same-permissions && mv package $OUT' % (url, url)
     if patches:
         cmd += ' && for SRC in $SRCS; do patch -p0 -l -i $SRC; done'
@@ -40,7 +41,7 @@ def yarn_library(name, version, package_name=None, out=None, hashes=None, test_o
         output_is_complete = False,
         visibility = visibility,
         exported_deps = deps,
-        labels = ['yarn:%s@%s' % (package_name or name, version)],
+        labels = ['yarn:%s@%s' % (package_name, version)],
     )
 
 def yarn_binary(name:str, package:str, deps:list=None, visibility:list=None, labels:list = None):

--- a/js/yarn.build_defs
+++ b/js/yarn.build_defs
@@ -1,6 +1,6 @@
 subinclude('//remote')
 
-def yarn_library(name, version, out=None, hashes=None, test_only=False, patches=None,
+def yarn_library(name, version, package_name=None, out=None, hashes=None, test_only=False, patches=None,
                  visibility=None, deps=None, _tag=''):
     """Install a third-party library from the Yarn registry.
 
@@ -16,6 +16,7 @@ def yarn_library(name, version, out=None, hashes=None, test_only=False, patches=
     Args:
       name (str): Name of the rule.
       version (str): Version of the package to install.
+      package_name (str): The name of the package. Defaults to the name.
       out (str): Output name for this package. Defaults to name.
       hashes (list): List of hashes that outputs must match.
       test_only (bool): If True, can only be depended on by test rules.
@@ -23,7 +24,7 @@ def yarn_library(name, version, out=None, hashes=None, test_only=False, patches=
       visibility (list): Visibility declaration for this rule.
       deps (list): Any other dependencies of the rule.
     """
-    url = 'https://registry.yarnpkg.com/%s/-/%s-%s.tgz' % (name, name, version)
+    url = 'https://registry.yarnpkg.com/%s/-/%s-%s.tgz' % (package_name or name, package_name or name, version)
     cmd = 'echo "Fetching %s..." && curl -fsSL %s | tar -xz --no-same-owner --no-same-permissions && mv package $OUT' % (url, url)
     if patches:
         cmd += ' && for SRC in $SRCS; do patch -p0 -l -i $SRC; done'
@@ -39,7 +40,7 @@ def yarn_library(name, version, out=None, hashes=None, test_only=False, patches=
         output_is_complete = False,
         visibility = visibility,
         exported_deps = deps,
-        labels = ['yarn:%s@%s' % (name, version)],
+        labels = ['yarn:%s@%s' % (package_name or name, version)],
     )
 
 def yarn_binary(name:str, package:str, deps:list=None, visibility:list=None, labels:list = None):


### PR DESCRIPTION
Some node packages are namespaced (ie: `@semantic-release/gitlab`) which doesn't play well with please's naming contracts. Furthermore, it is nice to allow to have the name of the rule to be different from the underlying node package. This makes it consistent with other rules.