### PR TITLE
Update //python:requirements to allow comments after dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently contains the following:
  * Rust: A very basic set of rules for building Rust code. Hasn't gone much beyond "hello world" yet.
  * Protocol Buffers: Extensions to the builtin proto rules, currently one to generate a REST proxy
    using [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway)
+ * Python: Basic rules for importing dependencies from `requirements.txt`. Does not support all possible entries yet.
  * Java: An extended compiler worker that integrates
    [error-prone](https://github.com/google/error-prone) for additional compile-time diagnostics.
  * Scala: Basic rules for compiling scala code to `.jar` files. No test support yet.

--- a/python/requirements.build_defs
+++ b/python/requirements.build_defs
@@ -13,8 +13,8 @@ def requirements_txt(name:str, src:str='requirements.txt', zip_safe:bool=True, t
         cmd = 'cat $SRCS',
         post_build = lambda _, output: [add_dep(name, auto_pip_library(
             name = line.partition('=')[0].rstrip('>=< '),
-            package = line.partition('#')[0].rstrip('\\ '),
-        )) for line in output if not (line.startswith('#') or line.startswith(' '))],
+            package = line.partition('#')[0].rstrip('\\ '), # remove comments and strip continuation character
+        )) for line in output if not (line.startswith('#') or line.startswith(' '))], # skip lines beginning with a comment or space
         deps = deps,
     )
     return filegroup(

--- a/python/requirements.build_defs
+++ b/python/requirements.build_defs
@@ -13,8 +13,8 @@ def requirements_txt(name:str, src:str='requirements.txt', zip_safe:bool=True, t
         cmd = 'cat $SRCS',
         post_build = lambda _, output: [add_dep(name, auto_pip_library(
             name = line.partition('=')[0].rstrip('>=< '),
-            package = line.partition('#')[0].rstrip('\\ '), # remove comments and strip continuation character
-        )) for line in output if not (line.startswith('#') or line.startswith(' '))], # skip lines beginning with a comment or space
+            package = line.partition('#')[0].rstrip(' '), # remove comments and strip spaces
+        )) for line in output if not line.startswith('#')],
         deps = deps,
     )
     return filegroup(

--- a/python/requirements.build_defs
+++ b/python/requirements.build_defs
@@ -13,8 +13,8 @@ def requirements_txt(name:str, src:str='requirements.txt', zip_safe:bool=True, t
         cmd = 'cat $SRCS',
         post_build = lambda _, output: [add_dep(name, auto_pip_library(
             name = line.partition('=')[0].rstrip('>=< '),
-            package = line,
-        )) for line in output if not line.startswith('#')],
+            package = line.partition('#')[0].rstrip('\\ '),
+        )) for line in output if not (line.startswith('#') or line.startswith(' '))],
         deps = deps,
     )
     return filegroup(

--- a/python/test/requirements.txt
+++ b/python/test/requirements.txt
@@ -1,5 +1,4 @@
 # Allow any version of six
 six
 # Specify a particular version (not the latest) of attrs.
-# Excerpt from a file generated with `pip-compile --generate-hashes`
 attrs==18.1.0 # Allow comments after a dependency

--- a/python/test/requirements.txt
+++ b/python/test/requirements.txt
@@ -1,4 +1,7 @@
 # Allow any version of six
 six
 # Specify a particular version (not the latest) of attrs.
-attrs==18.1.0
+# Excerpt from a file generated with `pip-compile --generate-hashes`
+attrs==18.1.0 \
+    --hash=sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265 \
+    --hash=sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b

--- a/python/test/requirements.txt
+++ b/python/test/requirements.txt
@@ -2,6 +2,4 @@
 six
 # Specify a particular version (not the latest) of attrs.
 # Excerpt from a file generated with `pip-compile --generate-hashes`
-attrs==18.1.0 \
-    --hash=sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265 \
-    --hash=sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b
+attrs==18.1.0 # Allow comments after a dependency


### PR DESCRIPTION
I'm a fan of please and [pip-compile](https://github.com/jazzband/pip-tools) and ideally I would like to use them together ~~(particularly for the hashing functionality!)~~

To enable this I've updated the `//python:requirements` rules to try and improve the parsing of the `requirements.txt` file