### PR TITLE
Update nim rules

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -6,6 +6,8 @@ path = /usr/local/bin:/usr/bin:/bin
 ; It's quite likely that anyone using Rust will have it here.
 path = ~/.cargo/bin
 path = ~/.yarn/bin
+path = ~/.nimble/bin
+PassEnv = USER
 
 [go]
 importpath = github.com/thought-machine/pleasings

--- a/nim/example_import/BUILD
+++ b/nim/example_import/BUILD
@@ -4,6 +4,6 @@ nim_binary(
     name = "main",
     main = "main.nim",
     deps = [
-        "//third_party/nim:wings",
+        "//third_party/nim:stones",
     ]
 )

--- a/nim/example_import/main.nim
+++ b/nim/example_import/main.nim
@@ -1,3 +1,3 @@
-import wingspkg/core
+import stones/log
 
-echo "Import successful!"
+LOG(SUCCESS, "Import successful!")

--- a/nim/nim.build_defs
+++ b/nim/nim.build_defs
@@ -1,9 +1,12 @@
-def nim_binary(name:str, main:str, srcs:list=[], out:str=None, test_only:bool=False, visibility:list=None, deps:list=[]):
+def nim_binary(name:str, main:str, srcs:list=[], out:str=None, opts:list=[], test_only:bool=False, visibility:list=None, deps:list=[]):
     out = out or name
 
+    compile_options = ' '.join(opts)
+
     cmd = ' && '.join([
+        _home_path(),
         _nimble_path(),
-        "$TOOL --verbosity:2 --NimblePath:$NIMBLE_PATH/pkgs -o:" + out + " c $PKG_DIR/" + main,
+        "$TOOL --verbosity:2 --NimblePath:$NIMBLE_PATH/pkgs -o:" + out + " " + compile_options + " c $PKG_DIR/" + main,
     ])
 
     return build_rule(
@@ -13,7 +16,7 @@ def nim_binary(name:str, main:str, srcs:list=[], out:str=None, test_only:bool=Fa
         tools = [CONFIG.NIM_TOOL],
         cmd = cmd,
         deps = deps,
-        requires = ["nim"],
+        requires = [CONFIG.NIM_TOOL],
         test_only = test_only,
         binary = True,
         visibility = visibility,
@@ -25,6 +28,7 @@ def nimble_install(name:str, pkg_name:str=None, revision:str=None, test_only:boo
     pkg = pkg_name + "@" + revision
 
     cmd = ' && '.join([
+        _home_path(),
         _nimble_path(),
         "$TOOL --accept --verbose --nimbleDir:$NIMBLE_PATH install " + pkg,
         "ln -s $NIMBLE_PATH/pkgs/" + pkg_name + "* ./",
@@ -36,13 +40,16 @@ def nimble_install(name:str, pkg_name:str=None, revision:str=None, test_only:boo
         cmd = cmd,
         deps = deps,
         outs = [pkg_name + "-" + revision],
-        requires = ["nimble"],
+        requires = [CONFIG.NIMBLE_TOOL],
         test_only = test_only,
         visibility = visibility,
     )
 
 def _nimble_path():
     return "NIMBLE_PATH=$(pwd | awk -F'plz-out' '{print $1}')\"plz-out/.nimble\""
+
+def _home_path():
+  return "if [[ \"$OSTYPE\" == \"darwin\"* ]]; then HOME=\"/Users/$USER\"; elif [[ \"$OSTYPE\" == \"linux-gnu\"* ]]; then HOME=\"/home/$USER\"; fi",
 
 CONFIG.setdefault('NIM_TOOL', 'nim')
 CONFIG.setdefault('NIMBLE_TOOL', 'nimble')

--- a/third_party/nim/BUILD
+++ b/third_party/nim/BUILD
@@ -2,6 +2,6 @@ package(default_visibility = ['PUBLIC'])
 subinclude('//nim')
 
 nimble_install(
-    name = "wings",
-    pkg_name = "wings",
+    name = "stones",
+    pkg_name = "stones",
 )


### PR DESCRIPTION
Not sure if there's any limitation against passing USER env value but this seems to be needed when nim / nimble is installed with choosenim (which is now the preferred way to do so).