### PR TITLE
Fix #57 docker fqn replace with --arch on macOS

### DIFF
--- a/k8s/k8s.build_defs
+++ b/k8s/k8s.build_defs
@@ -60,7 +60,7 @@ def k8s_config(name:str, srcs:list, containers:list=[], params:dict=None, visibi
         )
 
         # macos sed only supports posix regex expressions so escape sequences like \b don't work
-        boundary_expr = "\\b" if CONFIG.OS != 'darwin' else ""
+        boundary_expr = "\\b" if CONFIG.HOSTOS != 'darwin' else ""
         subcommands = ' '.join([
             f'-e "s|{container}{boundary_expr}|$(cat $(location {fqn}))|g"'
             for container, fqn in sorted(zip(containers, fqns))


### PR DESCRIPTION
Whilst using --arch to cross compile binaries for particular docker images on macOS, the docker image fqn would not be replaced in a k8s template.
By switching CONFIG.OS to CONFIG.HOSTOS we cannot override the OS sed command using --arch.