### PR TITLE
OCI Images

### DIFF
--- a/oci/BUILD
+++ b/oci/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "oci",
+    srcs = ["oci.build_defs"],
+    visibility = ["PUBLIC"],
+)

--- a/oci/README
+++ b/oci/README
@@ -1,0 +1,50 @@
+# OCI Images
+
+There are 3 approaches to containers in Please:
+1) Generate .sh files to run `docker build` against a docker context tarball (///pleasings//docker)
+2) Build up OCI images by creating our own layers in please build rules (https://github.com/tcncloud/please.containers)
+3) Build OCI containers, optionally using Dockerfiles, using buildah and podman (https://github.com/containers/buildah)
+
+These rules aim for the last option. They're less mature than the first option but allow the use of Dockerfiles while
+still building the container images at build time.
+
+## A disclaimer about build directories
+
+Buildah creates folders in namespaces that Please doesn't have permissions to delete. These rules try their best to
+clean up after themselves however they may still leave files and folders on disk if the build action terminates midway
+through. For this reason, these files and folders and created under `/tmp` so they will be cleaned up on system
+restarts. This breaks one of the core tenets of Please: don't access files outside the build directory. If this is a
+concern for you, then I recommend investigating one of the other two options above.
+
+## Why?
+
+- Docker has disadvantages for building containers with please. It must be run as root and is an external daemon with
+  its own state that prevents hermetic incremental builds. The docker rules just produce a .sh file to push the images
+  docker which must be ran subsequently.
+- OCI images are supported by docker but also other container engines, giving more flexibility whilst also being
+  backwards compatible.
+- Moving away from docker allows us to follow the unix philosophy with many smaller tools doing one thing well. i.e.
+  buildah, skopeo, podman, cri-o etc.
+- Using these tools means that images can be built by Please, so can then be cached as artefacts like any other. We can't
+  cache images in please without duplicating layers in large tarballs.
+
+## What?
+
+- Adds a container_image() rule that is almost backwards compatible with the docker_image() rule, except that it does
+  not assume that you want to use a dockerfile, so it doesn't default to dockerfile="Dockerfile". You also need to
+  specify transitive base images.
+- Uses buildah to build images and skopeo to move them around. Neither run as root. You can still use docker to run them
+  or use podman instead. Image hashes and artifacts are deterministic, no issues with timestamps etc. please struggles to
+  delete the ephemeral image cache due to permissions as it is created by rootless buildah (uid=0 and gid=0) so the
+  image cache is a tempdir under /tmp (/tmp on the machine, not the one under plz-out). On the happy path this is
+  deleted after each build. Worst case, it is deleted at system restart.
+- Adds some examples which also function as tests. The main example is copied from the docker image rule.
+
+
+## Future work:
+
+- Having to explicitly specify transitive base images, although well worth the remote caching gains, is a bit of a pain.
+  Could add a pre-build rule similar to add_dep() but for data instead.
+- Investigate improvements on the Please side to delete the temp files created by buildah. Everything is unprivileged so
+  in theory, Please should be able to `chown` files and folders before attempting to remove them after running a build
+  action.

--- a/oci/example/BUILD
+++ b/oci/example/BUILD
@@ -1,0 +1,19 @@
+subinclude("//oci")
+
+python_binary(
+    name = "example",
+    main = "example.py",
+)
+
+oci_image(
+    name = "base",
+    containerfile = 'Dockerfile-base',
+)
+
+oci_image(
+    name = "image",
+    srcs = [":example"],
+    base_image = ":base",
+    run_args = "",
+    visibility = ["//k8s/example:all"],
+)

--- a/oci/example/BUILD
+++ b/oci/example/BUILD
@@ -5,15 +5,44 @@ python_binary(
     main = "example.py",
 )
 
-oci_image(
-    name = "base",
-    containerfile = 'Dockerfile-base',
+# demonstrating backwards compatibility,
+container_image(
+    name = "docker_style_base",
+    dockerfile = "Dockerfile-base",
+    visibility = ['PUBLIC']
+)
+# although you do have to specify a dockerfile explicitly, as it is no longer always required.
+container_image(
+    name = "docker_style_image",
+    srcs = [":example"],
+    dockerfile = "Dockerfile",
+    base_image = ":docker_style_base",
+    visibility = ["//k8s/example:all"],
 )
 
-oci_image(
-    name = "image",
+# demonstrating transitive_base_images
+# pointless intermediate image as an example
+container_image(
+    name = "intermediate_image",
+    base_image = ':docker_style_base',
+)
+container_image(
+    name = "multiple_base_image",
     srcs = [":example"],
-    base_image = ":base",
-    run_args = "",
+    base_image = ":intermediate_image",
+    transitive_base_images = [':docker_style_base'],
+    visibility = ["//k8s/example:all"],
+)
+
+# demonstrating use of distroless images
+container_image(
+    name = "python_distroless",
+    base_image = 'gcr.io/distroless/python3@sha256:72684cdc6e9405189ad24356248950f5480b02db35ab59dfee9f849769feec33',
+)
+# notice no containerfile or cmd/entrypoint required
+container_image(
+    name = "distroless_image",
+    srcs = [":example"],
+    base_image = ":python_distroless",
     visibility = ["//k8s/example:all"],
 )

--- a/oci/example/Dockerfile
+++ b/oci/example/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/python3
+FROM any-placeholder-here
 COPY . .
 CMD [ "example.pex" ]

--- a/oci/example/Dockerfile
+++ b/oci/example/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/python3
+COPY . .
+CMD [ "example.pex" ]

--- a/oci/example/Dockerfile-base
+++ b/oci/example/Dockerfile-base
@@ -1,0 +1,3 @@
+FROM alpine:3.7
+
+RUN apk update && apk add python3

--- a/oci/example/example.py
+++ b/oci/example/example.py
@@ -1,0 +1,22 @@
+"""Example Python web server."""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.wfile.write(b'Hello world!\n')
+
+
+def main():
+    address = ('', 8000)
+    server = HTTPServer(address, Handler)
+    print('Serving on      localhost:8000')
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/oci/example/example.py
+++ b/oci/example/example.py
@@ -14,7 +14,7 @@ class Handler(BaseHTTPRequestHandler):
 def main():
     address = ('', 8000)
     server = HTTPServer(address, Handler)
-    print('Serving on      localhost:8000')
+    print('Serving on localhost:8000')
     server.serve_forever()
 
 

--- a/oci/oci.build_defs
+++ b/oci/oci.build_defs
@@ -1,68 +1,150 @@
-def oci_image(name:str, base_image:str='', srcs:list=[], image:str='', version:str='',
-                 dockerfile:str='', containerfile:str='', entrypoint:list=[], repo:str='', labels:list=[],
-                 run_args:str='', test_only:bool=False, visibility:list=None):
-    """oci_image defines a build rule for an OCI image.
+def container_image(
+    name:str, base_image='', transitive_base_images=[], srcs=[],image='', version='', dockerfile='',
+    containerfile='', entrypoint=[], cmd=[], repo=CONFIG.get('DEFAULT_DOCKER_REPO', ''),
+    labels=[], test_only=False, visibility:list=None
+):
+    """Build an OCI-compliant image. Uses incremental layering to optimise for please. The OCI
+    Specification standardises the docker image format https://github.com/opencontainers/image-spec.
 
-    You must use `plz run` to actually build the target.
+    You must have buildah and skopeo installed. They don't run as root so you may need to add to the
+    user namespaces in /etc/subuid and /etc/subgid. If your build fails from this you can try:
+    `usermod --add-subuids <unused subuid>-165535 --add-subgids <unused subgid>-165535 <username>`
+    'Fuse-overlayfs' is also recommended for faster builds. Once installed, buildah will start using
+    it automatically.
+    Docker is not required for builds, but you will need either podman or docker to run the images.
 
     Args:
       name: Name of the rule.
-      base_image: The build target that defines the base image. Only necessary if this image
-                  is based off another plz image.
+      base_image: The build target or image name to use as a base. Overrides the 'FROM' command in a
+                  Containerfile. If supplying an image name instead of a target, include the digest
+                  to ensure deterministic builds.
+      transitive_base_images: A list of container_image targets on which the base_image depends, if
+                              any. Required as artifacts do not contain the layers of their bases.
       srcs: Source files that are available within the containerfile.
-      image: Name of the image to create.
-      containerfile: The Dockerfile that defines how to build this image.
-      repo: Repository to store this image in. If not given then you'll need to set
-            default-oci-repo in the [buildconfig] section of your .plzconfig.
+      image: Name of the image to create, otherwise defaults to the rule path.
+      version: Optional version to tag the image. If not set, a hash will be used.
+      containerfile: Optional Containerfile or Dockerfile that defines how to build this image.
+      dockerfile: Duplicate of 'containerfile', for backwards compatability.
+      entrypoint: (when not using containerfile) The entrypoint of the image, as a list of commands.
+      cmd: (when not using containerfile) The 'cmd' of the image, as a list of commands. For
+           single-source images, defaults to a command running that source.
+      repo: Optional repository to hold this image. Can also provide env var when calling '_push'.
       labels: Labels to tag this rule with.
-      run_args: Any additional arguments to provide to 'oci run'.
       test_only: If True, this can only be depended on by test rules.
       visibility: Visibility of this rule.
     """
-    image = image or f"$PKG/{name}"
-    assert not image.startswith('//'), 'image argument is not a build label (should not start with //)'
-    if dockerfile:
-        containerfile = dockerfile
-
-    # image rule, builds the image and stores it as an oci formatted directory.
-    all_srcs = {}
-    context = ""
-    cmd = ["trap '$TOOL rmi -af' EXIT"]
-    if base_image:
-        if base_image.startswith("//") or base_image.startswith(":"):
-            all_srcs['base'] = [f'{base_image}']
-            base_image = 'from oci:"$SRCS_BASE"'
-        else:
-            base_image = f'from "{base_image}"'
-    if srcs:
-        context = "$TMPDIR/context"
-        all_srcs['context'] = srcs
-        cmd += [f"mkdir {context}", f"mv $SRCS_CONTEXT {context}"]
+    img_id = f"$PKG/{name}"
+    image = image or img_id
+    assert not image.startswith('//'), 'cannot use a build label for image argument'
+    if repo and not repo.endswith('/'):
+        repo += '/'
     if containerfile:
-        all_srcs['containerfile'] = [f'{containerfile}']
-        containerfile = '-f "$SRCS_CONTAINERFILE"'
-        if base_image:
-            base_image = f'--{base_image}'
-        cmd += [f'$TOOL bud --timestamp 0 {base_image} {containerfile} -t "{image}" {context}']
-    else:
-        cmd += [f'ctr=$($TOOL {base_image})']
+        dockerfile = containerfile
+    transitive_base_images = [canonicalise(rule) for rule in transitive_base_images]
+    base_image_target = base_image
+
+    def assert_transitive_base_images_present():
+        """
+        Currently no way to automatically add transitive 'data' dependencies,
+        so this checks the user has provided them explicitly.
+        """
+        bases = get_labels(base_image_target, 'base:')
+        for base in bases:
+            assert base in transitive_base_images, f"{base} missing from transitive_base_images arg"
+
+    def format_base_image(srcs_dict:dict, cmds:list, labels:list):
+        """
+        Format the base image for use by buildah.
+        """
+        pre_build = None
+        # if the base is target, add its layers and those of its parents as dependencies
+        if base_image.startswith("//") or base_image.startswith(":"):
+            pre_build = lambda rule: assert_transitive_base_images_present()
+            base_image = canonicalise(base_image)
+            labels += [f'base:{base_image}']
+            srcs_dict['base'] = [base_image]
+            base_image = 'oci:"$SRCS_BASE"'
+            if transitive_base_images:
+                srcs_dict['transitive_base'] = transitive_base_images
+                for base in transitive_base_images:
+                    # link the missing layers from the base's parents into the base layer store
+                    cmds += [f'cp -l $(location {base})/blobs/sha256/* "$SRCS_BASE/blobs/sha256"']
+        return base_image, cmds, labels, pre_build
+
+    def context(srcs_dict:dict, cmds:list):
+        """
+        Collect the source files in a temporary context dir.
+        """
+        context = ''
         if srcs:
-            cmd += [f'$TOOL copy "$ctr" {context} .']
+            context = "$TMPDIR/context"
+            srcs_dict['context'] = srcs
+            cmds += [f'mkdir "{context}"', f'mv "$SRCS_CONTEXT" "{context}"']
+        return context, cmds
+
+    def build_using_dockerfile(srcs_dict:dict, cmds:list, base_image:str, context:str):
+        """
+        Essentially a 'docker build', but using buildah
+        """
+        srcs_dict['dockerfile'] = [f'{dockerfile}']
+        if base_image:
+            base_image = f'--from "{base_image}"'
+        cmds += [f'$TOOL bud --timestamp 0 {base_image} -f "$SRCS_DOCKERFILE" -t "{img_id}" "{context}"']
+        return img_id, cmds
+
+    def build(srcs_dict:dict, cmds:list, base_image:str, context:str, entrypoint:list, cmd:list):
+        """
+        Without a dockerfile, use the buildah cli to add layers
+        """
+        cmds += [f'ctr=$($TOOL from "{base_image}")']
+        if context:
+            cmds += [f'$TOOL copy "$ctr" "{context}" .']
         if entrypoint:
-            cmd += [f'$TOOL config --entrypoint "{entrypoint}" "$ctr"']
-        cmd += [f'$TOOL commit "$ctr" "{image}"']
-    cmd += [f'$TOOL push "{image}" "oci:$OUT"']
+            entrypoint = _format_exec_list(entrypoint)
+            cmds += [f'$TOOL config --entrypoint "{entrypoint}" "$ctr"']
+        elif not cmd and 'context' in srcs_dict and len(srcs_dict['context']) == 1:
+            # default command runs the source if only one is provided
+            cmd = ['/`basename "$SRCS_CONTEXT"`']
+        if cmd:
+            cmd = _format_exec_list(cmd)
+            cmds += [f'$TOOL config --cmd "{cmd}" "$ctr"']
+        # commit the image and remove the working container
+        cmds += [f'$TOOL commit --omit-timestamp "$ctr" "{img_id}"', f'$TOOL rm "$ctr"']
+        return img_id, cmds
+
+    # image rule, builds the image and stores it as an oci-formatted dir.
+    srcs_dict = {}
+    cmds = [
+        # Buildah uses an image store, which can be ephemeral, except that please fails to delete it
+        # due to permissions. This uses a cache in the tempdir, but outside the build rule dir,
+        # where it doesnt have to be deleted by please. Also provides an i/o performance boost.
+        'STORE=${HOME%plz-out/*}plz-out/tmp/.containers/storage',
+        'TOOL="$TOOL --root=$STORE --runroot=/run/user/$UID"',
+    ]
+    base_image, cmds, labels, pre_build = format_base_image(srcs_dict, cmds, labels)
+    context, cmds = context(srcs_dict, cmds)
+    if dockerfile:
+        img_id, cmds = build_using_dockerfile(srcs_dict, cmds, base_image, context)
+    else:
+        img_id, cmds = build(srcs_dict, cmds, base_image, context, entrypoint, cmd)
+    # Write the compressed layers to OUT then remove the image from buildah's store.
+    cmds += [f'$TOOL push "{img_id}" "oci:$OUT"', f'$TOOL rmi -f "{img_id}"']
+    if srcs_dict.get('base'):
+        # Remove base image layers, leaving a small incremental artifact for fast http caching.
+        cmds += ['cd "$SRCS_BASE/blobs/sha256"', 'find . -exec rm -rf $OUT/blobs/sha256/{} \;']
     image_rule = genrule(
-        name = name,
-        srcs = all_srcs,
-        cmd = ' && '.join(cmd),
-        outs = [f'{name}_oci'],
-        labels = labels + ["oci-image"],
-        visibility = visibility,
-        test_only = test_only,
-        tools = [CONFIG.BUILDAH_TOOL],
+        name=name,
+        srcs=srcs_dict,
+        cmd=cmds,
+        outs=[name],
+        labels=labels + ["container-image"],
+        pre_build=pre_build,
+        visibility=visibility,
+        test_only=test_only,
+        tools=[CONFIG.BUILDAH_TOOL],
     )
 
+    # tag_rule, either a unique hash or the supplied version.
     if version:
         srcs = []
     else:
@@ -74,85 +156,95 @@ def oci_image(name:str, base_image:str='', srcs:list=[], image:str='', version:s
         else:
             version = 'no_idea_how_to_compute_version_on_this_host'
     tag_rule = build_rule(
-        name = name + '_tag',
-        srcs = srcs,
-        cmd = f'echo -n "{version}" >> $OUT',
-        outs = [f'{name}_tag'],
-        labels = labels + ["oci-tag"],
-        visibility = visibility,
-        test_only = test_only,
+        name=name + '_tag',
+        srcs=srcs,
+        cmd=f'echo -n "{version}" >> $OUT',
+        outs=[f'{name}_tag'],
+        labels=labels + ["image-tag"],
+        visibility=visibility,
+        test_only=test_only,
     )
 
-    if repo:
-        repo += "/"
+    # fully qualified name in the format [repo/]image:tag. Tag is either version or a unique hash.
     fqn = build_rule(
-        name = name + '_fqn',
-        srcs = [tag_rule],
-        cmd = f'echo -n "{repo}{image}:`cat $SRC`" >> $OUT',
-        outs = [f'{name}_fqn'],
-        labels = labels + ["oci-fqn"],
-        visibility = visibility,
-        test_only = test_only,
+        name=name + '_fqn',
+        srcs=[tag_rule],
+        cmd=f'echo -n "{repo}{image}:`cat $SRC`" >> $OUT',
+        outs=[f'{name}_fqn'],
+        labels=labels + ["image-fqn"],
+        visibility=visibility,
+        test_only=test_only,
     )
 
-    # save_rule, duplicates build rule to match docker_image build defs
-    sh_cmd(
-        name = name + '_save',
-        data = [image_rule],
-        cmd = '',
-        visibility = visibility,
-        test_only = test_only,
-        labels = labels + ["oci-save"],
-    )
+    # for all run rules, first link base image(s) layers into the image store so it is complete.
+    data = [image_rule]
+    cmds = []
+    if srcs_dict.get('base'):
+        base_images = transitive_base_images + srcs_dict['base']
+        data += base_images
+        cmds += ['tmp_dir=\\\$(mktemp -d)', f'cp -rl $(out_location {image_rule})/* \\\$tmp_dir']
+        for base in base_images:
+            cmds += [f'cp -l $(out_location {base})/blobs/sha256/* "\\\$tmp_dir/blobs/sha256"']
+        img_loc = f'oci:\\\$tmp_dir'
+    else:
+        img_loc = f'oci:$(out_location {image_rule})'
 
-    # run_rule, loads the image and runs it using podman or docke if podman not found.
-    if run_args:
-        run_args = f"-- {run_args}"
+    # run_rule, runs the image using podman or docker if podman not found.
     cmd = f'''
-    if ! command -v {CONFIG.PODMAN_TOOL} &> /dev/null; then
-        {CONFIG.SKOPEO_TOOL} copy -q oci:$(out_location {image_rule}) "docker-daemon:`cat $SRC`"
-        docker run -it `cat $SRC` {run_args} \\\$@
+    if [ ! $(command -v {CONFIG.PODMAN_TOOL} &> /dev/null) ]; then
+        {CONFIG.SKOPEO_TOOL} copy -q {img_loc} "docker-daemon:`cat $SRC`"
+        docker run -it `cat $SRC` \\\$@
     else
-        {CONFIG.PODMAN_TOOL} run -it oci:$(out_location {image_rule}) {run_args} \\\$@
+        {CONFIG.PODMAN_TOOL} run -it {img_loc} \\\$@
     fi'''
     sh_cmd(
-        name = name + '_run',
-        cmd = cmd,
-        srcs = [fqn],
-        data = [image_rule],
-        visibility = visibility,
-        test_only = test_only,
-        labels = labels + ["oci-run"],
+        name=name + '_run',
+        cmd=cmds + [cmd],
+        srcs=[fqn],
+        data=data,
+        visibility=visibility,
+        test_only=test_only,
+        labels=labels + ["image-run"],
     )
 
     # push_rule, push the image to a registry or other destination
     # Configured with env vars:
-    # DEST: (skopeo repository type https://github.com/containers/skopeo), default is docker://
-    # REPO: e.g. docker.io/library, default is as provided on build target
-    # TAG: Image tag, default is version on the build target, or a unique hash.
-    cmd = f'{CONFIG.SKOPEO_TOOL} copy oci:$(out_location {image_rule}) '
-    cmd += f'\\\${{DEST:-docker://}}\\\${{REPO:-{repo}}}\\\${{REPO:+/}}{image}:\\\${{TAG:-`cat $SRC`}}'
+    # DEST: (skopeo repository type https://github.com/containers/skopeo), default is 'docker://'
+    # REPO: Image registry e.g. 'docker.io/library', default is from the build rule argument.
+    # TAG: Tag to export the image with, default is version on the build target, or a unique hash.
+    cmds += [
+        f'from="oci:$(out_location {image_rule})"',
+        f'to="\\\${{DEST:-docker://}}\\\${{REPO:-{repo}}}\\\${{REPO:+/}}{image}:\\\${{TAG:-`cat $SRC`}}"',
+        f'{CONFIG.SKOPEO_TOOL} copy -q {img_loc} "\\\$to"',
+        'echo "\\\$from copied to \\\$to"',
+    ]
     sh_cmd(
-        name = name + '_push',
-        cmd = cmd,
-        srcs = [tag_rule],
-        data = [image_rule],
-        visibility = visibility,
-        test_only = test_only,
-        labels = labels + ["oci-push"],
+        name=name + '_push',
+        cmd=cmds + [cmd],
+        srcs=[tag_rule],
+        data=data,
+        visibility=visibility,
+        test_only=test_only,
+        labels=labels + ["image-push"],
     )
-    # load_rule, essentially copy_rule but with the destination set to 'docker-daemon:'
+    # load_rule, essentially _push but with the destination set to 'docker-daemon:'
+    # loads the image into the local docker daemon for backwards compatibility
     sh_cmd(
-        name = name + '_load',
-        cmd = ['export DEST="docker-daemon:"', cmd],
-        srcs = [tag_rule],
-        data = [image_rule],
-        visibility = visibility,
-        test_only = test_only,
-        labels = labels + ["oci-load"],
+        name=name + '_load',
+        cmd=['export DEST="docker-daemon:"'] + cmds,
+        srcs=[tag_rule],
+        data=data,
+        visibility=visibility,
+        test_only=test_only,
+        labels=labels + ["image-load"],
     )
 
     return image_rule
+
+def _format_exec_list(cmds: list) -> str:
+    """get commands in the docker exec format e.g. ["cmd1", "cmd2"] """
+    cmds = '\\",\\"'.join(cmds)
+    return f'[\\"{cmds}\\"]'
 
 
 CONFIG.setdefault('BUILDAH_TOOL', 'buildah')

--- a/oci/oci.build_defs
+++ b/oci/oci.build_defs
@@ -1,0 +1,160 @@
+def oci_image(name:str, base_image:str='', srcs:list=[], image:str='', version:str='',
+                 dockerfile:str='', containerfile:str='', entrypoint:list=[], repo:str='', labels:list=[],
+                 run_args:str='', test_only:bool=False, visibility:list=None):
+    """oci_image defines a build rule for an OCI image.
+
+    You must use `plz run` to actually build the target.
+
+    Args:
+      name: Name of the rule.
+      base_image: The build target that defines the base image. Only necessary if this image
+                  is based off another plz image.
+      srcs: Source files that are available within the containerfile.
+      image: Name of the image to create.
+      containerfile: The Dockerfile that defines how to build this image.
+      repo: Repository to store this image in. If not given then you'll need to set
+            default-oci-repo in the [buildconfig] section of your .plzconfig.
+      labels: Labels to tag this rule with.
+      run_args: Any additional arguments to provide to 'oci run'.
+      test_only: If True, this can only be depended on by test rules.
+      visibility: Visibility of this rule.
+    """
+    image = image or f"$PKG/{name}"
+    assert not image.startswith('//'), 'image argument is not a build label (should not start with //)'
+    if dockerfile:
+        containerfile = dockerfile
+
+    # image rule, builds the image and stores it as an oci formatted directory.
+    all_srcs = {}
+    context = ""
+    cmd = ["trap '$TOOL rmi -af' EXIT"]
+    if base_image:
+        if base_image.startswith("//") or base_image.startswith(":"):
+            all_srcs['base'] = [f'{base_image}']
+            base_image = 'from oci:"$SRCS_BASE"'
+        else:
+            base_image = f'from "{base_image}"'
+    if srcs:
+        context = "$TMPDIR/context"
+        all_srcs['context'] = srcs
+        cmd += [f"mkdir {context}", f"mv $SRCS_CONTEXT {context}"]
+    if containerfile:
+        all_srcs['containerfile'] = [f'{containerfile}']
+        containerfile = '-f "$SRCS_CONTAINERFILE"'
+        if base_image:
+            base_image = f'--{base_image}'
+        cmd += [f'$TOOL bud --timestamp 0 {base_image} {containerfile} -t "{image}" {context}']
+    else:
+        cmd += [f'ctr=$($TOOL {base_image})']
+        if srcs:
+            cmd += [f'$TOOL copy "$ctr" {context} .']
+        if entrypoint:
+            cmd += [f'$TOOL config --entrypoint "{entrypoint}" "$ctr"']
+        cmd += [f'$TOOL commit "$ctr" "{image}"']
+    cmd += [f'$TOOL push "{image}" "oci:$OUT"']
+    image_rule = genrule(
+        name = name,
+        srcs = all_srcs,
+        cmd = ' && '.join(cmd),
+        outs = [f'{name}_oci'],
+        labels = labels + ["oci-image"],
+        visibility = visibility,
+        test_only = test_only,
+        tools = [CONFIG.BUILDAH_TOOL],
+    )
+
+    if version:
+        srcs = []
+    else:
+        srcs = [image_rule]
+        if CONFIG.HOSTOS == 'linux':
+            version = f'$(echo $(hash {image_rule}) | sha256sum - | cut -f1 -d" ")'
+        elif CONFIG.HOSTOS == 'darwin':
+            version = f'$(echo $(hash {image_rule}) | shasum -a 256 - | cut -f1 -d" ")'
+        else:
+            version = 'no_idea_how_to_compute_version_on_this_host'
+    tag_rule = build_rule(
+        name = name + '_tag',
+        srcs = srcs,
+        cmd = f'echo -n "{version}" >> $OUT',
+        outs = [f'{name}_tag'],
+        labels = labels + ["oci-tag"],
+        visibility = visibility,
+        test_only = test_only,
+    )
+
+    if repo:
+        repo += "/"
+    fqn = build_rule(
+        name = name + '_fqn',
+        srcs = [tag_rule],
+        cmd = f'echo -n "{repo}{image}:`cat $SRC`" >> $OUT',
+        outs = [f'{name}_fqn'],
+        labels = labels + ["oci-fqn"],
+        visibility = visibility,
+        test_only = test_only,
+    )
+
+    # save_rule, duplicates build rule to match docker_image build defs
+    sh_cmd(
+        name = name + '_save',
+        data = [image_rule],
+        cmd = '',
+        visibility = visibility,
+        test_only = test_only,
+        labels = labels + ["oci-save"],
+    )
+
+    # run_rule, loads the image and runs it using podman or docke if podman not found.
+    if run_args:
+        run_args = f"-- {run_args}"
+    cmd = f'''
+    if ! command -v {CONFIG.PODMAN_TOOL} &> /dev/null; then
+        {CONFIG.SKOPEO_TOOL} copy -q oci:$(out_location {image_rule}) "docker-daemon:`cat $SRC`"
+        docker run -it `cat $SRC` {run_args} \\\$@
+    else
+        {CONFIG.PODMAN_TOOL} run -it oci:$(out_location {image_rule}) {run_args} \\\$@
+    fi'''
+    sh_cmd(
+        name = name + '_run',
+        cmd = cmd,
+        srcs = [fqn],
+        data = [image_rule],
+        visibility = visibility,
+        test_only = test_only,
+        labels = labels + ["oci-run"],
+    )
+
+    # push_rule, push the image to a registry or other destination
+    # Configured with env vars:
+    # DEST: (skopeo repository type https://github.com/containers/skopeo), default is docker://
+    # REPO: e.g. docker.io/library, default is as provided on build target
+    # TAG: Image tag, default is version on the build target, or a unique hash.
+    cmd = f'{CONFIG.SKOPEO_TOOL} copy oci:$(out_location {image_rule}) '
+    cmd += f'\\\${{DEST:-docker://}}\\\${{REPO:-{repo}}}\\\${{REPO:+/}}{image}:\\\${{TAG:-`cat $SRC`}}'
+    sh_cmd(
+        name = name + '_push',
+        cmd = cmd,
+        srcs = [tag_rule],
+        data = [image_rule],
+        visibility = visibility,
+        test_only = test_only,
+        labels = labels + ["oci-push"],
+    )
+    # load_rule, essentially copy_rule but with the destination set to 'docker-daemon:'
+    sh_cmd(
+        name = name + '_load',
+        cmd = ['export DEST="docker-daemon:"', cmd],
+        srcs = [tag_rule],
+        data = [image_rule],
+        visibility = visibility,
+        test_only = test_only,
+        labels = labels + ["oci-load"],
+    )
+
+    return image_rule
+
+
+CONFIG.setdefault('BUILDAH_TOOL', 'buildah')
+CONFIG.setdefault('SKOPEO_TOOL', 'skopeo')
+CONFIG.setdefault('PODMAN_TOOL', 'podman')

--- a/oci/test_image/Containerfile
+++ b/oci/test_image/Containerfile
@@ -1,0 +1,59 @@
+FROM thoughtmachine/please_ubuntu:latest
+MAINTAINER peter.ebden@gmail.com
+
+# OpenFST / Thrax
+WORKDIR /tmp
+RUN curl -sSf http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-1.6.3.tar.gz | tar -xz && \
+    cd openfst-1.6.3 && \
+    ./configure --prefix=/usr --enable-static --enable-shared --enable-lookahead-fsts --enable-grm --enable-compact-fsts --enable-const-fsts --enable-far && \
+    make -j4 && \
+    make install && \
+    rm -rf /tmp/openfst-1.6.3
+# Note that Thrax installs some things for root:staff, which fails on CircleCI, so we chown
+# them back to root:root again.
+RUN curl -sSf http://www.openfst.org/twiki/pub/GRM/ThraxDownload/thrax-1.2.3.tar.gz | tar -xz && \
+    cd thrax-1.2.3 && \
+    ./configure --prefix=/usr --enable-static --enable-shared && \
+    make -j4 && \
+    make install && \
+    rm -rf /tmp/thrax-1.2.3 && \
+    chown -R root:root /usr/share /usr/bin
+
+# Node (for js / yarn)
+RUN curl -sSL https://deb.nodesource.com/setup_6.x | bash -
+RUN apt-get install -y nodejs
+
+# Android
+ENV ANDROID_HOME "/opt/android"
+ENV ANDROID_NDK_HOME "/opt/android/ndk-bundle"
+ENV PATH "$PATH:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_NDK_HOME}/"
+RUN apt-get -qq update && \
+    apt-get install -qqy --no-install-recommends libc6-i386 lib32stdc++6 lib32gcc1 lib32ncurses5 lib32z1
+RUN curl https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip -fsSLo /tmp/tools.zip \
+    && unzip /tmp/tools.zip -d $ANDROID_HOME && \
+    rm /tmp/tools.zip
+RUN mkdir $ANDROID_HOME/licenses && echo -n -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > $ANDROID_HOME/licenses/android-sdk-license && \
+    echo -e "84831b9409646a918e30573bab4c9c91346d8abd" > $ANDROID_HOME/licenses/android-sdk-preview-license && \
+    $ANDROID_HOME/tools/bin/sdkmanager "platform-tools" \
+    "tools" \
+    "build-tools;25.0.3" \
+    "platforms;android-25" \
+    "ndk-bundle"
+RUN $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-26"
+
+# Python gRPC codegen plugin
+# This is a prebuilt version to avoid having to do a full-blown compile of the whole thing.
+RUN curl -fsSLo /usr/local/bin/grpc_python_plugin https://get.please.build/third_party/binary/grpc_python_plugin-1.4.0 && \
+    chmod +x /usr/local/bin/grpc_python_plugin
+
+# New version of Clang (for ThinLTO)
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" > /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install -y clang-6.0
+
+# pip (python deps)
+RUN apt-get install -y python3-pip
+
+# nim dependency
+RUN apt-get install nim


### PR DESCRIPTION
**Why?**
- Docker has disadvantages for building containers with please. It must be run as root and is an external daemon with its own state that prevents hermetic incremental builds. The current command to build docker images is a run command, not a build command.
- OCI images are supported by docker but also other container engines, giving more flexibility whilst also being backwards compatible.
- Moving away from docker allows us to follow the unix philosophy with many smaller tools doing one thing well. i.e. _**buildah**_, **_skopeo_**, **_podman_**, **_cri-o_** etc.
- Using these tools means that images can be built using a build rule, not a run command, and they can be cached as artefacts like any other. We can cache images in please without duplicating layers in large tarballs. 

**What?**
- Adds a `container_image() `rule that is **almost** backwards compatible with the `docker_image()` rule, except that it does not assume that you want to use a dockerfile, so it doesn't default to `dockerfile="Dockerfile"`. You also need to specify transitive base images.
- Uses _buildah_ to build images and _skopeo_ to move them around. Neither run as root. You can still use docker to run them or use _podman_ instead. 
- image hashes and artifacts are deterministic, no issues with timestamps etc.
- please struggles to delete the ephemeral image cache due to permissions as it is created by rootless buildah (uid=0 and gid=0) so the image cache is a tempdir under /tmp (/tmp on the machine, not the one under plz-out). On the happy path this is deleted after each build. Worst case, it is deleted at system restart.
-  Adds some examples which also function as tests. The main example is copied from the docker image rule.
- See the documentation on the build def for more info.

**Future work:**
- Having to explicitly specify transitive base images, although well worth the remote caching gains, is a bit of a pain. Could add a pre-build rule similar to add_dep() but for data instead.