### PR TITLE
Support go_mock with Please v16+

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,12 @@
+name: Go
+on: [push]
+jobs:
+  go:
+    name: Test Go Rules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Test Go Rules
+        run: ./pleasew test //go/...

--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [please]
-version = >=15.15.0
+version = >=16.0.0
 
 [build]
 path = /usr/local/bin:/usr/bin:/bin

--- a/go/go_mock.build_defs
+++ b/go/go_mock.build_defs
@@ -66,7 +66,6 @@ def go_mock(name:str, src_lib:str, visibility:list=None, deps:list=[], package:s
     go_library(
         name=name,
         visibility=visibility,
-        out=f"{name}.a",
         srcs=[mock_srcs],
         test_only=True,
         deps=[


### PR DESCRIPTION
👋 

just came across this while trying to upgrade Dracon to Plz v16

```
plz-out/gen/third_party/subrepos/pleasings/go/go_mock.build_defs:66:5: error: Unknown argument to go_library: out
```

This PR fixes by just removing the parameter and added a GitHub action to verify `plz test //go/...` still passes happily :)

Let me know if you have any suggestions/changes - happy to oblige