### PR TITLE
OCI: Fix the context directory

### DIFF
--- a/oci/oci.build_defs
+++ b/oci/oci.build_defs
@@ -77,7 +77,7 @@ def container_image(
         """
         context = ''
         if srcs:
-            context = "$TMPDIR/context"
+            context = "$STORE/context"
             srcs_dict['context'] = srcs
             cmds += [f'mkdir "{context}"', f'mv "$SRCS_CONTEXT" "{context}"']
         return context, cmds


### PR DESCRIPTION
`$TMPDIR` is not a variable in this script. It was used while creating `$STORE`, but was ephemeral, so it's an empty string when used where this change was made. Changing the context dir to be in the `$STORE`.

**before**

```
STORE=$(TMPDIR=/tmp mktemp -d) \
&& TOOL="$TOOL --root=$STORE/containers --runroot=$STORE/run" \
&& mkdir "$TMPDIR/context" \                                <--- evaluated to `/context`
&& mv "$SRCS_CONTEXT" "$TMPDIR/context" \
...
```

**after**

```
STORE=$(TMPDIR=/tmp mktemp -d) \
&& TOOL="$TOOL --root=$STORE/containers --runroot=$STORE/run" \
&& mkdir "$STORE/context" \
&& mv "$SRCS_CONTEXT" "$STORE/context" \
...
```

P.S.  I'm very happy this pleasing was added! I'm enjoying using it so far!