### PR TITLE
OCI: shell conditional

### DIFF
--- a/oci/oci.build_defs
+++ b/oci/oci.build_defs
@@ -193,7 +193,7 @@ def container_image(
 
     # run_rule, runs the image using podman or docker if podman not found.
     cmd = f'''
-    if ! $(command -v {CONFIG.PODMAN_TOOL} &> /dev/null); then
+    if ! command -v {CONFIG.PODMAN_TOOL} &> /dev/null; then
         {CONFIG.SKOPEO_TOOL} copy -q {img_loc} "docker-daemon:`cat $SRC`"
         docker run -it `cat $SRC` \\\$@
     else

--- a/oci/oci.build_defs
+++ b/oci/oci.build_defs
@@ -193,7 +193,7 @@ def container_image(
 
     # run_rule, runs the image using podman or docker if podman not found.
     cmd = f'''
-    if [ ! $(command -v {CONFIG.PODMAN_TOOL} &> /dev/null) ]; then
+    if ! $(command -v {CONFIG.PODMAN_TOOL} &> /dev/null); then
         {CONFIG.SKOPEO_TOOL} copy -q {img_loc} "docker-daemon:`cat $SRC`"
         docker run -it `cat $SRC` \\\$@
     else


### PR DESCRIPTION
I'm very open to suggestion for this change! I know this is a common problem with shell scripting, and I'm not sure my solution is "correct".

The problem I'm having is that this conditional always evaluates to true on my machine. The outputted script looks like this:

```sh
#!/bin/sh

    if [ !  ]; then
        skopeo copy -q oci:plz-out/gen/src/api/api "docker-daemon:my-image"
        docker run -it my-image $@
    else
        podman run -it oci:plz-out/gen/my-image $@
    fi
```

I don't know if it's "correct" for the evaluation of `$(command -v {CONFIG.PODMAN_TOOL}...)` to occur in the build def, or if that should've been output as `$(command -v podman...)` to the shell script. I'm only doing local builds, so it's inconsequential for me.

At this point, I can say that I've had success with the conditional correctly evaluating when I remove the brackets. My machine does have `podman` installed, so I expect to evaluate false and run the `podman` command. If I replace `CONFIG.PODMAN_TOOL` with something my machine doesn't have, like `docker`, the conditional correctly evaluates to true.