### PR TITLE
OCI: Add push args

### DIFF
--- a/oci/oci.build_defs
+++ b/oci/oci.build_defs
@@ -1,7 +1,7 @@
 def container_image(
     name:str, base_image='', transitive_base_images=[], srcs=[],image='', version='', dockerfile='',
     containerfile='', entrypoint=[], cmd=[], repo=CONFIG.get('DEFAULT_DOCKER_REPO', ''),
-    labels=[], run_args:str='', test_only=False, visibility:list=None
+    labels=[], run_args:str='', push_args:str='', test_only=False, visibility:list=None
 ):
     """Build an OCI-compliant image. Uses incremental layering to optimise for please. The OCI
     Specification standardises the docker image format https://github.com/opencontainers/image-spec.
@@ -31,6 +31,7 @@ def container_image(
       repo: Optional repository to hold this image. Can also provide env var when calling '_push'.
       labels: Labels to tag this rule with.
       run_args: Any additional arguments to provide to 'podman run'.
+      push_args: Any additional arguments to provide to 'skopeo copy'.
       test_only: If True, this can only be depended on by test rules.
       visibility: Visibility of this rule.
     """
@@ -218,7 +219,7 @@ def container_image(
     cmds += [
         f'from="oci:$(out_location {image_rule})"',
         f'to="\\\${{DEST:-docker://}}\\\${{REPO:-{repo}}}\\\${{REPO:+/}}{image}:\\\${{TAG:-`cat $SRC`}}"',
-        f'{CONFIG.SKOPEO_TOOL} copy -q {img_loc} "\\\$to"',
+        f'{CONFIG.SKOPEO_TOOL} copy -q \\\${{PUSH_ARGS:-{push_args}}} {img_loc} "\\\$to"',
         'echo "\\\$from copied to \\\$to"',
     ]
     sh_cmd(


### PR DESCRIPTION
Unlike `docker push`, `skopeo copy` [has several agruments](https://github.com/containers/skopeo/blob/master/docs/skopeo-copy.1.md) which can be important to define on a per-registry basis.