### PR TITLE
WIP: Fix Terraform for macos

### DIFF
--- a/terraform/scripts/module_builder.sh
+++ b/terraform/scripts/module_builder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script prepares a Terraform module for use with Please by:
 # * Replacing sub-modules (deps) with local references.
 # * Ensuring all sub-modules have local references.

--- a/terraform/scripts/runner.sh
+++ b/terraform/scripts/runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script runs Terraform in the target's working directory with the following features:
 # - Plugin cache directory pointing to our prepared plugins directory.
 # - Strips out various noisy output (https://github.com/hashicorp/terraform/issues/20960)

--- a/terraform/scripts/workspace_builder.sh
+++ b/terraform/scripts/workspace_builder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script prepares a Terraform Workspace with:
 # * Terraform Plugins
 # * Terraform Modules
@@ -38,7 +38,10 @@ function plugins_v0.13+ {
         provider_name=$(<"${plugin}/.provider_name")
         version=$(<"${plugin}/.version")
         plugin_dir="${PLUGIN_DIR}/${registry}/${namespace}/${provider_name}/${version}/${CONFIG_OS}_${CONFIG_ARCH}"
-        plugin_bin="$(find "$plugin" -not -path '*/\.*' -type f | head -n1)"
+        # TODO: this returns the first matched file, problem if there are multiple files in the same archive
+        # there is a difference between GNU and BSD find
+        # https://stackoverflow.com/questions/4458120/search-for-executable-files-using-find-command/4458361#4458361
+        plugin_bin="$(find "$plugin" -not -path '*/\.*' -type f -perm +111 | head -n1)"
         mkdir -p "${plugin_dir}"
         cp "$plugin_bin" "${plugin_dir}/"
     done

--- a/terraform/terraform.build_defs
+++ b/terraform/terraform.build_defs
@@ -204,7 +204,7 @@ def terraform_root(
 
         sh_cmd(
             name = f"{name}_tf_{k}",
-            shell = "/bin/bash",
+            shell = "/usr/bin/env bash",
             cmd = f"""
 set -euo pipefail
 {_bash_version_check_cmd}
@@ -225,6 +225,7 @@ source "$(out_location {RUNNER_SRC})"
     _linters(name, toolchain, workspace, labels, visibility)
 
 _bash_version_check_cmd = """
+# TODO: this does not work as expected. The variables for checking the bash version are expanded before the script is run.
 if [ -z "${BASH_VERSINFO}" ] || [ -z "${BASH_VERSINFO[0]}" ] || [ ${BASH_VERSINFO[0]} -lt 4 ]; then 
     echo "This script requires Bash version >= 4"
     exit 1
@@ -295,7 +296,7 @@ def _linters(
 
         sh_cmd(
             name = f"{name}_tf_{k}",
-            shell = "/bin/bash",
+            shell = "/usr/bin/env bash",
             cmd = f"""
 set -euo pipefail
 {_bash_version_check_cmd}


### PR DESCRIPTION
The version of bash that comes with Macos 11.4 is ancient, 3.2, there I've installed a newer version using Homebrew which is available in my path, therefore changes the shebangs to use `/usr/bin/env` to locate the newer bash version.

Also updated the find method when searching for a binary in a Terraform provider to return the first **executable** file. This helps if the provider archive also contains other files like a README. 