### PR TITLE
Feature: Ability to pass docker `build_args` when creating docker image

### DIFF
--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -55,13 +55,16 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
         deps = [f'{base_image}_fqn' if base_image else None],
         labels = labels + ["docker-fqn"],
         stamp = True,
-        visibility = visibility,
         test_only = test_only,
         pass_env = pass_env,
     )
 
+    build_args_str=''
+    for arg in build_args:
+        build_args_str += f' --build-arg {arg}=$SECRET_{arg}'
+
     # docker build
-    cmd = f'env && docker build -t `cat $SRCS_FQN` -f $(basename $SRCS_DOCKERFILE) - < $(out_location {tarball})'
+    cmd = f'docker build {build_args_str} -t `cat $SRCS_FQN` -f $(basename $SRCS_DOCKERFILE) - < $(out_location {tarball})'
     if base_image:
         cmd = f'./$(out_location {base_image}) && {cmd}'
     docker_build = sh_cmd(

--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -1,6 +1,6 @@
 def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
                  dockerfile:str='Dockerfile', base_image:str='', repo:str='', labels:list=[],
-                 pass_env:list=[], run_args:str='', test_only:bool=False, visibility:list=None,  build_args:dict={}):
+                 pass_env:list=[], run_args:str='', test_only:bool=False, visibility:list=None,  build_args:list=[]):
     """docker_image defines a build rule for a Docker image.
 
     You must use `plz run` to actually build the target.

--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -1,6 +1,6 @@
 def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
                  dockerfile:str='Dockerfile', base_image:str='', repo:str='', labels:list=[],
-                 pass_env:list=[], run_args:str='', test_only:bool=False, visibility:list=None):
+                 pass_env:list=[], run_args:str='', test_only:bool=False, visibility:list=None,  build_args:dict={}):
     """docker_image defines a build rule for a Docker image.
 
     You must use `plz run` to actually build the target.

--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -1,6 +1,6 @@
 def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
                  dockerfile:str='Dockerfile', base_image:str='', repo:str='', labels:list=[],
-                 pass_env:list=[], run_args:str='', test_only:bool=False, visibility:list=None,  build_args:list=[]):
+                 pass_env:list=[], run_args:str='', test_only:bool=False, visibility:list=None, build_args:str=''):
     """docker_image defines a build rule for a Docker image.
 
     You must use `plz run` to actually build the target.
@@ -22,7 +22,7 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
       run_args: Any additional arguments to provide to 'docker run'.
       test_only: If True, this can only be depended on by test rules.
       visibility: Visibility of this rule.
-      build_args: Inject arguments from secrets when building the image.
+      build_args: Any arguments to provide to 'docker build'
     """
     image = image or name
     if base_image:
@@ -61,13 +61,8 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
         pass_env = pass_env,
     )
 
-    # create build_arg arguments
-    build_args_str=''
-    for arg in build_args:
-        build_args_str += f' --build-arg {arg}=$SECRET_{arg}'
-
     # docker build
-    cmd = f'docker build {build_args_str} -t `cat $SRCS_FQN` -f $(basename $SRCS_DOCKERFILE) - < $(out_location {tarball})'
+    cmd = f'docker build {build_args} -t `cat $SRCS_FQN` -f $(basename $SRCS_DOCKERFILE) - < $(out_location {tarball})'
     if base_image:
         cmd = f'./$(out_location {base_image}) && {cmd}'
     docker_build = sh_cmd(

--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -56,6 +56,7 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
         deps = [f'{base_image}_fqn' if base_image else None],
         labels = labels + ["docker-fqn"],
         stamp = True,
+        visibility = visibility,
         test_only = test_only,
         pass_env = pass_env,
     )

--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -22,6 +22,7 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
       run_args: Any additional arguments to provide to 'docker run'.
       test_only: If True, this can only be depended on by test rules.
       visibility: Visibility of this rule.
+      build_args: Inject arguments from secrets when building the image.
     """
     image = image or name
     if base_image:
@@ -59,6 +60,7 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
         pass_env = pass_env,
     )
 
+    # create build_arg arguments
     build_args_str=''
     for arg in build_args:
         build_args_str += f' --build-arg {arg}=$SECRET_{arg}'

--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -61,7 +61,7 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
     )
 
     # docker build
-    cmd = f'docker build -t `cat $SRCS_FQN` -f $(basename $SRCS_DOCKERFILE) - < $(out_location {tarball})'
+    cmd = f'env && docker build -t `cat $SRCS_FQN` -f $(basename $SRCS_DOCKERFILE) - < $(out_location {tarball})'
     if base_image:
         cmd = f'./$(out_location {base_image}) && {cmd}'
     docker_build = sh_cmd(


### PR DESCRIPTION
# changes

Feature - Allow injecting `SECRET_` variables into docker build when creating a docker image.

# usage

- Let's say you have to pass a `SERVICE_NAME` variable from the BuildEnv, you can pass it along to `PLZ_OVERRIDES` first (or add it to .plzconfig)

```bash
PLZ_OVERRIDES=buildenv.SECRET_SERVICE_NAME:'gateway'
```

- Now you can use it as a `build_arg` in the `docker_image` rule

```bazel
docker_image(
  name="gateway",
  srcs=glob(["*"], ["bin", "obj"]),
  dockerfile="//common/docker:dotnet_webapi",
  visibility=["//srv/gateway/..."],
  build_args=["SERVICE_NAME"]
)
```

The entire run command looks like this
```bash
PLZ_OVERRIDES=buildenv.SECRET_SERVICE_NAME:'gateway' plz run //srv/gateway
```

@Tatskaari saw a lot of comments from you so thought I can get a review from you as well. 😁