### PR TITLE
Terraform: Support colocation of modules with the same basename

### DIFF
--- a/terraform/scripts/terraform.sh
+++ b/terraform/scripts/terraform.sh
@@ -316,7 +316,7 @@ EOF
     terraform_workspace="${PLZ_TF_WORKSPACE_BASE}/$(echo "$root_module" | sed 's#^.*plz-out/gen##')"
     log::debug "workspace: ${terraform_workspace}"
     mkdir -p "${terraform_workspace}"
-    rsync -ah --delete --exclude=.terraform* "${root_module}/" "${terraform_workspace}/"
+    rsync -ah --delete --exclude=.terraform* --exclude=*.tfstate "${root_module}/" "${terraform_workspace}/"
 
     # change the end-user's working directory to the Terraform workspace, suitable for running `terraform` commands.
     cat <<EOF

--- a/terraform/scripts/terraform.sh
+++ b/terraform/scripts/terraform.sh
@@ -179,14 +179,16 @@ function _colocate_modules {
     if [ ${#modules[@]} -ne 0 ]; then
         mkdir "${out}/modules/"
         for m in "${modules[@]}"; do
-            replace="./modules/$(basename "$m")"
+            log::debug "colocating '${m}'"
+            replace="./modules/${m}"
 
             mapfile -t searches <"${m}/${PLZ_TF_METADATA_DIR}/.module_aliases"
             for search in "${searches[@]}"; do
-                log::debug "replacing ${search} with ${replace}"
+                log::debug "replacing '${search}' with '${replace}'"
                 find . -name "*.tf" -exec sed -i  "s#\"[^\"]*${search}[^\"]*\"#\"${replace}\"#g" {} +
             done
-            cp -r "$m" "${out}/modules/"
+            mkdir -p "${out}/modules/${m}"
+            cp -r "$m" "${out}/modules/$(dirname ${m})/"
         done
     fi
 }


### PR DESCRIPTION
This PR fixes support for the colocation of Terraform modules that have the same basename. Currently, this Terraform tool only copies the `basename` of the directory name, into the colocated `./modules/` folder in `terraform_root`s. 
For example, the current behaviour is:
* Given a `terraform_module` at `//modules/my_module_a/gcp:gcp` (`plz-out/gen/modules/my_module_a/gcp/gcp`)
* The tooling currently copies this to `./modules/gcp`.

This means that any other modules with the same basename will clash, For example:
* Given a `terraform_module` at `//modules/my_module_a/gcp:gcp` (`plz-out/gen/modules/my_module_a/gcp/gcp`)
* The tooling currently copies this to `./modules/gcp`.
* Given another `terraform_module` at `//modules/my_module_b/gcp:gcp` (`plz-out/gen/modules/my_module_b/gcp/gcp`)
* The tooling currently copies this to `./modules/gcp`, clashing with the other module.

This PR fixes this by changing the behaviour to:
* Given a `terraform_module` at `//modules/my_module_a/gcp:gcp` (`plz-out/gen/modules/my_module_a/gcp/gcp`)
* The tooling now copies this to `./modules/modules/my_module_a/gcp/gcp`.
* Given another `terraform_module` at `//modules/my_module_b/gcp:gcp` (`plz-out/gen/modules/my_module_b/gcp/gcp`)
* The tooling now copies this to `./modules/modules/my_module_b/gcp/gcp`.


I've also added another exclusion pattern for `*.tfstate` files to not be removed from `/tmp/please/...` so that people can still use non-remote terraform state (with its disadvantages) for demoing/testing purposes.
