### PR TITLE
Add args to container run

### DIFF
--- a/docker/docker.build_defs
+++ b/docker/docker.build_defs
@@ -1,6 +1,7 @@
 def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
                  dockerfile:str='Dockerfile', base_image:str='', repo:str='', labels:list=[],
-                 pass_env:list=[], run_args:str='', test_only:bool=False, visibility:list=None, build_args:str=''):
+                 pass_env:list=[], run_args:str='', test_only:bool=False, visibility:list=None, build_args:str='',
+                 container_args:str=''):
     """docker_image defines a build rule for a Docker image.
 
     You must use `plz run` to actually build the target.
@@ -23,6 +24,7 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
       test_only: If True, this can only be depended on by test rules.
       visibility: Visibility of this rule.
       build_args: Any arguments to provide to 'docker build'
+      container_args: Any arguments to provide to the container's entrypoint during 'docker run'
     """
     image = image or name
     if base_image:
@@ -92,7 +94,7 @@ def docker_image(name:str, srcs:list=[], image:str=None, version:str='',
     # docker run
     sh_cmd(
         name = name + '_run',
-        cmd = f'./$(out_location {docker_build}) && docker run -it {run_args} `cat $SRCS`',
+        cmd = f'./$(out_location {docker_build}) && docker run -it {run_args} `cat $SRCS` {container_args}',
         srcs = [fqn],
         deps = [docker_build],
         visibility = visibility,

--- a/docker/example/BUILD
+++ b/docker/example/BUILD
@@ -16,4 +16,5 @@ docker_image(
     base_image = ":base",
     run_args = "-p 8000:8000",
     visibility = ["//k8s/example:all"],
+    container_args = "8000"
 )

--- a/docker/example/example.py
+++ b/docker/example/example.py
@@ -1,6 +1,7 @@
 """Example Python web server."""
 
 from http.server import BaseHTTPRequestHandler, HTTPServer
+import sys
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -12,9 +13,10 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def main():
-    address = ('', 8000)
+    port = sys.argv[1]
+    address = ('', int(port))
     server = HTTPServer(address, Handler)
-    print('Serving on localhost:8000')
+    print('Serving on localhost:'+port)
     server.serve_forever()
 
 


### PR DESCRIPTION
If you want to pass arguments to the entrypoint of the docker container when calling the run script currently there is no way to do this.